### PR TITLE
Fix incorrect error message

### DIFF
--- a/Bahn-Simulator/passanger.go
+++ b/Bahn-Simulator/passanger.go
@@ -154,10 +154,6 @@ func (p *Passenger) Update(w *World, e chan error, wg *sync.WaitGroup) {
 		}
 		train.L.Lock()
 		defer train.L.Unlock()
-		if !train.BoardingPossible {
-			e <- fmt.Errorf("passenger (%s): boarding not possible at %s", p.ID, train.ID)
-			return
-		}
 		station, ok := w.Stations[train.Position[0]]
 		if !ok {
 			e <- fmt.Errorf("passenger (%s): can not find station %s", p.ID, train.Position[0])


### PR DESCRIPTION
Checking the following example input and output returns the error message: `passengers - 5 - passenger (P1): boarding not possible at T1` although there is no boarding move at `5`. Seems to me that it is wrong to check if boarding can be made to a train when the move is `Detrain`.

input
```
[Stations]
S1 1
S2 1

[Lines]
L1 S1 S2 1 1

[Trains]
T1 S1 0.333333333333333333333333333 1

[Passengers]
P1 S1 S2 1 6
```

output
```
[Train:T1]
2 Depart L1

[Passenger:P1]
1 Board T1
5 Detrain
```